### PR TITLE
fix: Java 11 以上でもテストが通るように修正

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,9 +89,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.18.1</version>
-        <configuration>
-          <argLine>-Dfile.encoding=UTF-8</argLine>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Java 11 以上で動かす場合は jmockit 用に `-Djdk.attach.allowAttachSelf` という JVM 引数を設定する必要がある。
この設定は、 [nablarch-parent の pom.xml](https://github.com/nablarch/nablarch-parent/blob/5u20/pom.xml#L40) の `jvm.defaultArgLine` プロパティで共通設定されている。

しかし、このプロジェクトは `maven-surefire-plugin` の `argLine` を独自に設定してしまっていたため、上述の共通設定が適用されない状態になっていた。
このため、 Java 11 以上でテストを実行すると jmockit のエラーが発生するようになっていた。

`argLine` で独自に設定している文字コードの設定は、 nablarch-parent でも設定されているため、このプロジェクト独自での設定を削除した。

